### PR TITLE
Scenes refactor

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+RayTracer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ add_executable(RayTracer main.cpp
         Scenes/MatTestScene.h
         Scenes/BvhTestScene.cpp
         Scenes/BvhTestScene.h
+        Scenes/CornellBoxScene.cpp
+        Scenes/CornellBoxScene.h
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ add_executable(RayTracer main.cpp
         Scenes/BvhTestScene.h
         Scenes/CornellBoxScene.cpp
         Scenes/CornellBoxScene.h
+        Scenes/TestScene2.cpp
+        Scenes/TestScene2.h
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ add_executable(RayTracer main.cpp
         Scenes/ManyBallsScene.h
         Scenes/VolumeTestScene.cpp
         Scenes/VolumeTestScene.h
+        Scenes/MatTestScene.cpp
+        Scenes/MatTestScene.h
+        Scenes/BvhTestScene.cpp
+        Scenes/BvhTestScene.h
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ add_executable(RayTracer main.cpp
         Types/simd_utils.h
         Scenes/ManyBallsScene.cpp
         Scenes/ManyBallsScene.h
+        Scenes/VolumeTestScene.cpp
+        Scenes/VolumeTestScene.h
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ add_executable(RayTracer main.cpp
         Lights/PointLight.h
         Types/simd_utils.cpp
         Types/simd_utils.h
+        Scenes/ManyBallsScene.cpp
+        Scenes/ManyBallsScene.h
 )
 
 

--- a/Scene.h
+++ b/Scene.h
@@ -28,13 +28,21 @@ private:
     std::function<Vector3(Ray)> env_func;
 
 public:
+    std::string sceneName = "";
+
     Scene(){
         object_count = 0;
         objects = new SceneObject*[0];
         env_func = nullptr;
+        sceneName = nullptr;
     }
 
-    std::string sceneName = "";
+    explicit Scene(std::string name){
+        object_count = 0;
+        objects = new SceneObject*[0];
+        env_func = nullptr;
+        sceneName = name;
+    }
 
     int get_object_count();
     SceneObject** get_objects();

--- a/Scene.h
+++ b/Scene.h
@@ -34,6 +34,8 @@ public:
         env_func = nullptr;
     }
 
+    std::string sceneName = "";
+
     int get_object_count();
     SceneObject** get_objects();
     void add_object(SceneObject *object);
@@ -75,6 +77,8 @@ public:
         }
         return root->get_bounds();
     }
+
+    virtual void init_scene() = 0;
 };
 
 #endif //RAYTRACER_SCENE_H

--- a/Scenes/BvhTestScene.cpp
+++ b/Scenes/BvhTestScene.cpp
@@ -1,0 +1,38 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#include "BvhTestScene.h"
+#include "../Objects/Sphere.h"
+#include "../materials/Lambertian.h"
+#include "../materials/Metallic.h"
+#include "../materials/Dielectric.h"
+
+void BvhTestScene::init_scene() {
+    //grid of balls in front of the camera
+    int n_spheres = 100;
+    for(int i=0; i<n_spheres; i++){
+        auto* sphere = new Sphere(random_double(0.02, 0.04));
+        //on the ground, in front of the camera
+        double x = (i % 10) / 10.0;
+        double y = (i / 10) / 10.0;
+        sphere->Transform.set_position(Vector3(x, y, 1));
+        double mat_choice = random_double();
+        if(mat_choice < 0.33){
+            sphere->material = new Lambertian(Vector3::random(0,1));
+        } else if(mat_choice < 0.66){
+            sphere->material = new Metallic(Vector3::random(0,1), random_double(0, 0.5));
+        } else {
+            sphere->material = new Dielectric(Vector3(1, 1, 1), random_double(1.1, 2));
+        }
+
+        add_object(sphere);
+    }
+
+    //environment function
+    set_environment([](Ray ray){
+        auto unit_direction = ray.Direction.unit_vector();
+        auto t = 0.5 * (unit_direction.y + 1.0);
+        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
+    });
+}

--- a/Scenes/BvhTestScene.h
+++ b/Scenes/BvhTestScene.h
@@ -1,0 +1,18 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#ifndef RAYTRACER_BVHTESTSCENE_H
+#define RAYTRACER_BVHTESTSCENE_H
+
+
+#include "../Scene.h"
+
+class BvhTestScene : public Scene {
+public:
+    BvhTestScene() : Scene("BVHTestScene") {};
+    void init_scene() override;
+};
+
+
+#endif //RAYTRACER_BVHTESTSCENE_H

--- a/Scenes/CornellBoxScene.cpp
+++ b/Scenes/CornellBoxScene.cpp
@@ -1,0 +1,46 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#include "CornellBoxScene.h"
+#include "../Objects/AAB.h"
+#include "../materials/Lambertian.h"
+
+void CornellBoxScene::init_scene() {
+    //walls
+    auto* left_wall = new AAB(10, 10, 0.1, Vector3(-5, 0, 0));
+    left_wall->material = new Lambertian(Vector3(1, 0, 0));
+    add_object(left_wall);
+
+    auto* right_wall = new AAB(10, 10, 0.1, Vector3(5, 0, 0));
+    right_wall->material = new Lambertian(Vector3(0, 1, 0));
+    add_object(right_wall);
+
+    auto* back_wall = new AAB(0.1, 10, 10, Vector3(0, 0, -5));
+    back_wall->material = new Lambertian(Vector3(1, 1, 1));
+    add_object(back_wall);
+
+    auto* front_wall = new AAB(0.1, 10, 10, Vector3(0, 0, 5));
+    front_wall->material = new Lambertian(Vector3(1, 1, 1));
+    add_object(front_wall);
+
+    auto* top_wall = new AAB(10, 0.1, 10, Vector3(0, 5, 0));
+    top_wall->material = new Lambertian(Vector3(1, 1, 1));
+    add_object(top_wall);
+
+    auto* bottom_wall = new AAB(10, 0.1, 10, Vector3(0, -5, 0));
+    bottom_wall->material = new Lambertian(Vector3(1, 1, 1));
+    add_object(bottom_wall);
+
+    //light
+    auto* light = new AAB(1, 0.1, 1, Vector3(0, 4.9, 0));
+    light->material = new Lambertian(Vector3(1, 1, 1));
+    add_object(light);
+
+    //environment function
+    set_environment([](Ray ray){
+        auto unit_direction = ray.Direction.unit_vector();
+        auto t = 0.5 * (unit_direction.y + 1.0);
+        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3 (0.5, 0.7, 1.0);
+    });
+}

--- a/Scenes/CornellBoxScene.h
+++ b/Scenes/CornellBoxScene.h
@@ -1,0 +1,17 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#ifndef RAYTRACER_CORNELLBOXSCENE_H
+#define RAYTRACER_CORNELLBOXSCENE_H
+
+
+#include "../Scene.h"
+
+class CornellBoxScene : public Scene {
+public:
+    CornellBoxScene() : Scene("CornellBoxScene") {};
+    void init_scene() override;
+};
+
+#endif //RAYTRACER_CORNELLBOXSCENE_H

--- a/Scenes/ManyBallsScene.cpp
+++ b/Scenes/ManyBallsScene.cpp
@@ -9,9 +9,11 @@
 #include "../materials/Dielectric.h"
 
 ManyBallsScene::ManyBallsScene(int n_balls) {
-    //create scene
-    Scene = new class Scene();
+    this->n_balls = n_balls;
+}
 
+void ManyBallsScene::init_scene() {
+    //create scene
     auto* Ground = new AAB(10, 0.1, 10, Vector3(0, -1, 0));
     Ground->material = new Lambertian(Vector3(0.5, 0.5, 0.5));
     //scene->add_object(Ground);
@@ -30,11 +32,11 @@ ManyBallsScene::ManyBallsScene(int n_balls) {
             sphere->material = new Dielectric(Vector3(1, 1, 1), random_double(1.1, 2));
         }
 
-        Scene->add_object(sphere);
+        add_object(sphere);
     }
 
     //environment function
-    Scene->set_environment([](Ray ray){
+    set_environment([](Ray ray){
         auto unit_direction = ray.Direction.unit_vector();
         auto t = 0.5 * (unit_direction.y + 1.0);
         return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);

--- a/Scenes/ManyBallsScene.cpp
+++ b/Scenes/ManyBallsScene.cpp
@@ -1,0 +1,42 @@
+//
+// Created by airon on 03/09/2023.
+//
+#include "ManyBallsScene.h"
+#include "../Objects/AAB.h"
+#include "../materials/Lambertian.h"
+#include "../Objects/Sphere.h"
+#include "../materials/Metallic.h"
+#include "../materials/Dielectric.h"
+
+ManyBallsScene::ManyBallsScene(int n_balls) {
+    //create scene
+    Scene = new class Scene();
+
+    auto* Ground = new AAB(10, 0.1, 10, Vector3(0, -1, 0));
+    Ground->material = new Lambertian(Vector3(0.5, 0.5, 0.5));
+    //scene->add_object(Ground);
+
+    int n_spheres = n_balls;
+    for(int i=0; i<n_spheres; i++){
+        auto* sphere = new Sphere(random_double(0.05, 0.1));
+        //on the ground, in front of the camera
+        sphere->Transform.set_position(Vector3(random_double(-4, 4), random_double(-3,3), random_double(-4, 0)));
+        double mat_choice = random_double();
+        if(mat_choice < 0.33){
+            sphere->material = new Lambertian(Vector3::random(0,1));
+        } else if(mat_choice < 0.66){
+            sphere->material = new Metallic(Vector3::random(0,1), random_double(0, 0.5));
+        } else {
+            sphere->material = new Dielectric(Vector3(1, 1, 1), random_double(1.1, 2));
+        }
+
+        Scene->add_object(sphere);
+    }
+
+    //environment function
+    Scene->set_environment([](Ray ray){
+        auto unit_direction = ray.Direction.unit_vector();
+        auto t = 0.5 * (unit_direction.y + 1.0);
+        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
+    });
+}

--- a/Scenes/ManyBallsScene.cpp
+++ b/Scenes/ManyBallsScene.cpp
@@ -9,6 +9,7 @@
 #include "../materials/Dielectric.h"
 
 ManyBallsScene::ManyBallsScene(int n_balls) {
+    this->sceneName = "ManyBallsScene";
     this->n_balls = n_balls;
 }
 

--- a/Scenes/ManyBallsScene.cpp
+++ b/Scenes/ManyBallsScene.cpp
@@ -8,11 +8,6 @@
 #include "../materials/Metallic.h"
 #include "../materials/Dielectric.h"
 
-ManyBallsScene::ManyBallsScene(int n_balls) {
-    this->sceneName = "ManyBallsScene";
-    this->n_balls = n_balls;
-}
-
 void ManyBallsScene::init_scene() {
     //create scene
     auto* Ground = new AAB(10, 0.1, 10, Vector3(0, -1, 0));

--- a/Scenes/ManyBallsScene.h
+++ b/Scenes/ManyBallsScene.h
@@ -7,10 +7,11 @@
 
 #include "..\Scene.h"
 
-class ManyBallsScene {
+class ManyBallsScene : public Scene {
 public:
-    Scene* Scene;
-    ManyBallsScene(int n_balls);
+    int n_balls = 100;
+    explicit ManyBallsScene(int n_balls);
+    void init_scene() override;
 };
 
 #endif //RAYTRACER_MANYBALLSSCENE_H

--- a/Scenes/ManyBallsScene.h
+++ b/Scenes/ManyBallsScene.h
@@ -1,0 +1,16 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#ifndef RAYTRACER_MANYBALLSSCENE_H
+#define RAYTRACER_MANYBALLSSCENE_H
+
+#include "..\Scene.h"
+
+class ManyBallsScene {
+public:
+    Scene* Scene;
+    ManyBallsScene(int n_balls);
+};
+
+#endif //RAYTRACER_MANYBALLSSCENE_H

--- a/Scenes/ManyBallsScene.h
+++ b/Scenes/ManyBallsScene.h
@@ -10,7 +10,7 @@
 class ManyBallsScene : public Scene {
 public:
     int n_balls = 100;
-    explicit ManyBallsScene(int n_balls);
+    explicit ManyBallsScene(int n_balls) : Scene("ManyBallsScene"){this->n_balls = n_balls;};
     void init_scene() override;
 };
 

--- a/Scenes/MatTestScene.cpp
+++ b/Scenes/MatTestScene.cpp
@@ -1,0 +1,38 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#include "MatTestScene.h"
+#include "../Objects/AAB.h"
+#include "../materials/Lambertian.h"
+#include "../Objects/Sphere.h"
+#include "../materials/Dielectric.h"
+#include "../materials/Metallic.h"
+
+void MatTestScene::init_scene() {
+    auto* Ground = new AAB(10, 0.1, 10, Vector3(0, -1, 0));
+    Ground->material = new Lambertian(Vector3(0.5, 0.5, 0.5));
+    add_object(Ground);
+
+    auto* sphere = new Sphere(1);
+    sphere->Transform.set_position(Vector3(-2, .5, -1));
+    sphere->material = new Dielectric(Vector3(1, 0,0), 1.5);
+    add_object(sphere);
+
+    auto* sphere2 = new Sphere(1);
+    sphere2->Transform.set_position(Vector3(0, .5, -1));
+    sphere2->material = new Metallic(Vector3(1,1,0), 0.1);
+    add_object(sphere2);
+
+    auto* sphere3 = new Sphere(1);
+    sphere3->Transform.set_position(Vector3(2, .5, -1));
+    sphere3->material = new Lambertian(Vector3(0,0,1));
+    add_object(sphere3);
+
+    //environment function
+    set_environment([](Ray ray){
+        auto unit_direction = ray.Direction.unit_vector();
+        auto t = 0.5 * (unit_direction.y + 1.0);
+        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
+    });
+}

--- a/Scenes/MatTestScene.h
+++ b/Scenes/MatTestScene.h
@@ -1,0 +1,18 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#ifndef RAYTRACER_MATTESTSCENE_H
+#define RAYTRACER_MATTESTSCENE_H
+
+
+#include "../Scene.h"
+
+class MatTestScene : public Scene {
+public:
+    explicit MatTestScene() : Scene("MatTestScene") {};
+    void init_scene() override;
+};
+
+
+#endif //RAYTRACER_MATTESTSCENE_H

--- a/Scenes/TestScene2.cpp
+++ b/Scenes/TestScene2.cpp
@@ -1,0 +1,40 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#include "TestScene2.h"
+#include "../Objects/AAB.h"
+#include "../materials/Lambertian.h"
+#include "../Objects/Sphere.h"
+#include "../materials/Metallic.h"
+#include "../materials/Dielectric.h"
+
+void TestScene2::init_scene() {
+    AAB* ground = new AAB(10, 0.1, 10, Vector3(0, -0.05, 0));
+    ground->material = new Lambertian(Vector3(0.8, 0.8, 0.8));
+    add_object(ground);
+
+    int balls = 500;
+    for(int i=0; i<balls; i++){
+        auto* sphere = new Sphere(random_double(0.05, 0.1));
+        //on the ground, in front of the camera
+        sphere->Transform.set_position(Vector3(random_double(-2, 2), sphere->radius, random_double(-2,2)));
+        double mat_choice = random_double();
+        if(mat_choice < 0.33){
+            sphere->material = new Lambertian(Vector3::random(0,1));
+        } else if(mat_choice < 0.66){
+            sphere->material = new Metallic(Vector3::random(0,1), random_double(0, 0.5));
+        } else {
+            sphere->material = new Dielectric(Vector3(1, 1, 1), random_double(1.1, 2));
+        }
+
+        add_object(sphere);
+    }
+
+    //environment function
+    set_environment([](Ray ray){
+        auto unit_direction = ray.Direction.unit_vector();
+        auto t = 0.5 * (unit_direction.y + 1.0);
+        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
+    });
+}

--- a/Scenes/TestScene2.h
+++ b/Scenes/TestScene2.h
@@ -1,0 +1,17 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#ifndef RAYTRACER_TESTSCENE2_H
+#define RAYTRACER_TESTSCENE2_H
+
+
+#include "../Scene.h"
+
+class TestScene2 : public Scene {
+public:
+    TestScene2() : Scene("TestScene2") {};
+    void init_scene() override;
+};
+
+#endif //RAYTRACER_TESTSCENE2_H

--- a/Scenes/VolumeTestScene.cpp
+++ b/Scenes/VolumeTestScene.cpp
@@ -1,0 +1,32 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#include "VolumeTestScene.h"
+#include "../materials/VolumeTest.h"
+#include "../Objects/Sphere.h"
+#include "../materials/Lambertian.h"
+#include "../Objects/AAB.h"
+
+VolumeTestScene::VolumeTestScene() {
+    this->sceneName = "VolumeTestScene";
+}
+
+void VolumeTestScene::init_scene() {
+
+    auto* Ground = new AAB(1000, 0.1, 1000, Vector3(0, -1, 0));
+    Ground->material = new Lambertian(Vector3(0.5, 0.5, 0.5));
+    add_object(Ground);
+
+    auto* sphere = new Sphere(1);
+    sphere->Transform.set_position(Vector3(0, .5, -1));
+    sphere->material = new VolumeTest(Vector3(1, 1, 1), .5, 0.1);
+    add_object(sphere);
+
+    //environment function
+    set_environment([](Ray ray){
+        auto unit_direction = ray.Direction.unit_vector();
+        auto t = 0.5 * (unit_direction.y + 1.0);
+        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
+    });
+}

--- a/Scenes/VolumeTestScene.cpp
+++ b/Scenes/VolumeTestScene.cpp
@@ -8,10 +8,6 @@
 #include "../materials/Lambertian.h"
 #include "../Objects/AAB.h"
 
-VolumeTestScene::VolumeTestScene() {
-    this->sceneName = "VolumeTestScene";
-}
-
 void VolumeTestScene::init_scene() {
 
     auto* Ground = new AAB(1000, 0.1, 1000, Vector3(0, -1, 0));

--- a/Scenes/VolumeTestScene.h
+++ b/Scenes/VolumeTestScene.h
@@ -10,7 +10,7 @@
 
 class VolumeTestScene : public Scene{
 public:
-    explicit VolumeTestScene();
+    VolumeTestScene() : Scene("VolumeTestScene") {}
     void init_scene() override;
 };
 

--- a/Scenes/VolumeTestScene.h
+++ b/Scenes/VolumeTestScene.h
@@ -1,0 +1,18 @@
+//
+// Created by airon on 03/09/2023.
+//
+
+#ifndef RAYTRACER_VOLUMETESTSCENE_H
+#define RAYTRACER_VOLUMETESTSCENE_H
+
+
+#include "../Scene.h"
+
+class VolumeTestScene : public Scene{
+public:
+    explicit VolumeTestScene();
+    void init_scene() override;
+};
+
+
+#endif //RAYTRACER_VOLUMETESTSCENE_H

--- a/main.cpp
+++ b/main.cpp
@@ -13,8 +13,13 @@
 #include "Types/Window.h"
 #include <Windows.h>
 #include <chrono>
+#include <vector>
 
 #include "oidn/include/OpenImageDenoise/oidn.hpp"
+#include "Scenes/ManyBallsScene.h"
+
+//TODO: properly fix this by using inherited classes
+std::vector<std::unique_ptr<Scene>> scenes;
 
 Scene* many_balls_scene(int n_balls);
 Scene* mat_test_scene();
@@ -26,9 +31,16 @@ void Vector3_unit_test();
 
 void test_bvh_depth(Scene* scene, Camera* camera, Window* window, int depth_max);
 
+void prepare_scenes(){
+    scenes.push_back(std::make_unique<ManyBallsScene>(100));
+}
+
 int main(int argc, char* argv[]) {
     //test_image();
     //test_pattern();
+
+    //TODO: see where this actually belongs in chronological order
+    prepare_scenes();
 
     Vector3_unit_test();
 
@@ -51,7 +63,10 @@ int main(int argc, char* argv[]) {
     camera->max_bounces = argc > 4 ? atoi(argv[4]) : 10;
 
     //create scene
-    Scene* scene = test_scene_2();
+    //Scene* scene = test_scene_2();
+    Scene* scene = scenes[0].get();
+    //build the scene
+    scene->init_scene();
     camera->set_scene(scene);
 
     //camera.look_at(camera.Transform.forward() + camera.Transform.position());
@@ -133,7 +148,7 @@ int main(int argc, char* argv[]) {
     window->close();
     return 0;
 }
-
+/*
 Scene* volume_test_scene(){
     Scene* scene = new Scene();
 
@@ -320,7 +335,7 @@ Scene* test_scene_2(){
 
     return scene;
 }
-
+*/
 void Vector3_unit_test(){
     Vector3 v1(1, 2, 3);
     Vector3 v2(4, 5, 6);

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,7 @@
 #include "Scenes/VolumeTestScene.h"
 #include "Scenes/MatTestScene.h"
 #include "Scenes/BvhTestScene.h"
+#include "Scenes/CornellBoxScene.h"
 
 //TODO: properly fix this by using inherited classes
 std::vector<std::unique_ptr<Scene>> scenes;
@@ -33,6 +34,7 @@ void prepare_scenes(){
     scenes.push_back(std::make_unique<VolumeTestScene>());
     scenes.push_back(std::make_unique<MatTestScene>());
     scenes.push_back(std::make_unique<BvhTestScene>());
+    scenes.push_back(std::make_unique<CornellBoxScene>());
 }
 
 int main(int argc, char* argv[]) {
@@ -64,7 +66,7 @@ int main(int argc, char* argv[]) {
 
     //create scene
     //Scene* scene = test_scene_2();
-    Scene* scene = scenes[3].get();
+    Scene* scene = scenes[4].get();
     //build the scene
     scene->init_scene();
     camera->set_scene(scene);
@@ -149,48 +151,6 @@ int main(int argc, char* argv[]) {
     return 0;
 }
 /*
-Scene* cornell_box_scene(){
-    Scene* scene = new Scene();
-
-    //walls
-    auto* left_wall = new AAB(10, 10, 0.1, Vector3(-5, 0, 0));
-    left_wall->material = new Lambertian(Vector3(1, 0, 0));
-    scene->add_object(left_wall);
-
-    auto* right_wall = new AAB(10, 10, 0.1, Vector3(5, 0, 0));
-    right_wall->material = new Lambertian(Vector3(0, 1, 0));
-    scene->add_object(right_wall);
-
-    auto* back_wall = new AAB(0.1, 10, 10, Vector3(0, 0, -5));
-    back_wall->material = new Lambertian(Vector3(1, 1, 1));
-    scene->add_object(back_wall);
-
-    auto* front_wall = new AAB(0.1, 10, 10, Vector3(0, 0, 5));
-    front_wall->material = new Lambertian(Vector3(1, 1, 1));
-    scene->add_object(front_wall);
-
-    auto* top_wall = new AAB(10, 0.1, 10, Vector3(0, 5, 0));
-    top_wall->material = new Lambertian(Vector3(1, 1, 1));
-    scene->add_object(top_wall);
-
-    auto* bottom_wall = new AAB(10, 0.1, 10, Vector3(0, -5, 0));
-    bottom_wall->material = new Lambertian(Vector3(1, 1, 1));
-    scene->add_object(bottom_wall);
-
-    //light
-    auto* light = new AAB(1, 0.1, 1, Vector3(0, 4.9, 0));
-    light->material = new Lambertian(Vector3(1, 1, 1));
-    scene->add_object(light);
-
-    //environment function
-    scene->set_environment([](Ray ray){
-        auto unit_direction = ray.Direction.unit_vector();
-        auto t = 0.5 * (unit_direction.y + 1.0);
-        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3 (0.5, 0.7, 1.0);
-    });
-
-    return scene;
-}
 
 void test_bvh_depth(Scene* scene, Camera* camera, Window* window, int depth_max){
     //bvh times array

--- a/main.cpp
+++ b/main.cpp
@@ -134,41 +134,6 @@ int main(int argc, char* argv[]) {
     return 0;
 }
 
-Scene* many_balls_scene(int n_balls){
-    //create scene
-    Scene* scene = new Scene();
-
-    auto* Ground = new AAB(10, 0.1, 10, Vector3(0, -1, 0));
-    Ground->material = new Lambertian(Vector3(0.5, 0.5, 0.5));
-    //scene->add_object(Ground);
-
-    int n_spheres = n_balls;
-    for(int i=0; i<n_spheres; i++){
-        auto* sphere = new Sphere(random_double(0.05, 0.1));
-        //on the ground, in front of the camera
-        sphere->Transform.set_position(Vector3(random_double(-4, 4), random_double(-3,3), random_double(-4, 0)));
-        double mat_choice = random_double();
-        if(mat_choice < 0.33){
-            sphere->material = new Lambertian(Vector3::random(0,1));
-        } else if(mat_choice < 0.66){
-            sphere->material = new Metallic(Vector3::random(0,1), random_double(0, 0.5));
-        } else {
-            sphere->material = new Dielectric(Vector3(1, 1, 1), random_double(1.1, 2));
-        }
-
-        scene->add_object(sphere);
-    }
-
-    //environment function
-    scene->set_environment([](Ray ray){
-        auto unit_direction = ray.Direction.unit_vector();
-        auto t = 0.5 * (unit_direction.y + 1.0);
-        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
-    });
-
-    return scene;
-}
-
 Scene* volume_test_scene(){
     Scene* scene = new Scene();
 

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@
 #include "oidn/include/OpenImageDenoise/oidn.hpp"
 #include "Scenes/ManyBallsScene.h"
 #include "Scenes/VolumeTestScene.h"
+#include "Scenes/MatTestScene.h"
 
 //TODO: properly fix this by using inherited classes
 std::vector<std::unique_ptr<Scene>> scenes;
@@ -35,6 +36,7 @@ void test_bvh_depth(Scene* scene, Camera* camera, Window* window, int depth_max)
 void prepare_scenes(){
     scenes.push_back(std::make_unique<ManyBallsScene>(100));
     scenes.push_back(std::make_unique<VolumeTestScene>());
+    scenes.push_back(std::make_unique<MatTestScene>());
 }
 
 int main(int argc, char* argv[]) {
@@ -66,7 +68,7 @@ int main(int argc, char* argv[]) {
 
     //create scene
     //Scene* scene = test_scene_2();
-    Scene* scene = scenes[1].get();
+    Scene* scene = scenes[2].get();
     //build the scene
     scene->init_scene();
     camera->set_scene(scene);
@@ -151,37 +153,6 @@ int main(int argc, char* argv[]) {
     return 0;
 }
 /*
-Scene* mat_test_scene(){
-    Scene* scene = new Scene();
-
-    auto* Ground = new AAB(10, 0.1, 10, Vector3(0, -1, 0));
-    Ground->material = new Lambertian(Vector3(0.5, 0.5, 0.5));
-    scene->add_object(Ground);
-
-    auto* sphere = new Sphere(1);
-    sphere->Transform.set_position(Vector3(-2, .5, -1));
-    sphere->material = new Dielectric(Vector3(1, 0,0), 1.5);
-    scene->add_object(sphere);
-
-    auto* sphere2 = new Sphere(1);
-    sphere2->Transform.set_position(Vector3(0, .5, -1));
-    sphere2->material = new Metallic(Vector3(1,1,0), 0.1);
-    scene->add_object(sphere2);
-
-    auto* sphere3 = new Sphere(1);
-    sphere3->Transform.set_position(Vector3(2, .5, -1));
-    sphere3->material = new Lambertian(Vector3(0,0,1));
-    scene->add_object(sphere3);
-
-    //environment function
-    scene->set_environment([](Ray ray){
-        auto unit_direction = ray.Direction.unit_vector();
-        auto t = 0.5 * (unit_direction.y + 1.0);
-        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
-    });
-
-    return scene;
-}
 
 Scene* bvh_test_scene(){
     Scene* scene = new Scene();

--- a/main.cpp
+++ b/main.cpp
@@ -19,16 +19,11 @@
 #include "Scenes/ManyBallsScene.h"
 #include "Scenes/VolumeTestScene.h"
 #include "Scenes/MatTestScene.h"
+#include "Scenes/BvhTestScene.h"
 
 //TODO: properly fix this by using inherited classes
 std::vector<std::unique_ptr<Scene>> scenes;
 
-Scene* many_balls_scene(int n_balls);
-Scene* mat_test_scene();
-Scene* volume_test_scene();
-Scene* bvh_test_scene();
-Scene* cornell_box_scene();
-Scene* test_scene_2();
 void Vector3_unit_test();
 
 void test_bvh_depth(Scene* scene, Camera* camera, Window* window, int depth_max);
@@ -37,6 +32,7 @@ void prepare_scenes(){
     scenes.push_back(std::make_unique<ManyBallsScene>(100));
     scenes.push_back(std::make_unique<VolumeTestScene>());
     scenes.push_back(std::make_unique<MatTestScene>());
+    scenes.push_back(std::make_unique<BvhTestScene>());
 }
 
 int main(int argc, char* argv[]) {
@@ -68,7 +64,7 @@ int main(int argc, char* argv[]) {
 
     //create scene
     //Scene* scene = test_scene_2();
-    Scene* scene = scenes[2].get();
+    Scene* scene = scenes[3].get();
     //build the scene
     scene->init_scene();
     camera->set_scene(scene);
@@ -153,40 +149,6 @@ int main(int argc, char* argv[]) {
     return 0;
 }
 /*
-
-Scene* bvh_test_scene(){
-    Scene* scene = new Scene();
-
-    //grid of balls in front of the camera
-    int n_spheres = 100;
-    for(int i=0; i<n_spheres; i++){
-        auto* sphere = new Sphere(random_double(0.02, 0.04));
-        //on the ground, in front of the camera
-        double x = (i % 10) / 10.0;
-        double y = (i / 10) / 10.0;
-        sphere->Transform.set_position(Vector3(x, y, 1));
-        double mat_choice = random_double();
-        if(mat_choice < 0.33){
-            sphere->material = new Lambertian(Vector3::random(0,1));
-        } else if(mat_choice < 0.66){
-            sphere->material = new Metallic(Vector3::random(0,1), random_double(0, 0.5));
-        } else {
-            sphere->material = new Dielectric(Vector3(1, 1, 1), random_double(1.1, 2));
-        }
-
-        scene->add_object(sphere);
-    }
-
-    //environment function
-    scene->set_environment([](Ray ray){
-        auto unit_direction = ray.Direction.unit_vector();
-        auto t = 0.5 * (unit_direction.y + 1.0);
-        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
-    });
-
-    return scene;
-}
-
 Scene* cornell_box_scene(){
     Scene* scene = new Scene();
 

--- a/main.cpp
+++ b/main.cpp
@@ -3,13 +3,6 @@
 #include "Camera.h"
 #include "utils.h"
 #include "Scene.h"
-#include "Objects/Sphere.h"
-#include "Objects/AAB.h"
-#include "materials/Lambertian.h"
-#include "materials/Metallic.h"
-#include "materials/Dielectric.h"
-#include "Texture.h"
-#include "materials/VolumeTest.h"
 #include "Types/Window.h"
 #include <Windows.h>
 #include <chrono>
@@ -21,6 +14,7 @@
 #include "Scenes/MatTestScene.h"
 #include "Scenes/BvhTestScene.h"
 #include "Scenes/CornellBoxScene.h"
+#include "Scenes/TestScene2.h"
 
 //TODO: properly fix this by using inherited classes
 std::vector<std::unique_ptr<Scene>> scenes;
@@ -35,6 +29,7 @@ void prepare_scenes(){
     scenes.push_back(std::make_unique<MatTestScene>());
     scenes.push_back(std::make_unique<BvhTestScene>());
     scenes.push_back(std::make_unique<CornellBoxScene>());
+    scenes.push_back(std::make_unique<TestScene2>());
 }
 
 int main(int argc, char* argv[]) {
@@ -66,7 +61,7 @@ int main(int argc, char* argv[]) {
 
     //create scene
     //Scene* scene = test_scene_2();
-    Scene* scene = scenes[4].get();
+    Scene* scene = scenes[5].get();
     //build the scene
     scene->init_scene();
     camera->set_scene(scene);
@@ -150,7 +145,6 @@ int main(int argc, char* argv[]) {
     window->close();
     return 0;
 }
-/*
 
 void test_bvh_depth(Scene* scene, Camera* camera, Window* window, int depth_max){
     //bvh times array
@@ -175,40 +169,6 @@ void test_bvh_depth(Scene* scene, Camera* camera, Window* window, int depth_max)
     }
 }
 
-Scene* test_scene_2(){
-    auto scene = new Scene();
-
-    AAB* ground = new AAB(10, 0.1, 10, Vector3(0, -0.05, 0));
-    ground->material = new Lambertian(Vector3(0.8, 0.8, 0.8));
-    scene->add_object(ground);
-
-    int balls = 500;
-    for(int i=0; i<balls; i++){
-        auto* sphere = new Sphere(random_double(0.05, 0.1));
-        //on the ground, in front of the camera
-        sphere->Transform.set_position(Vector3(random_double(-2, 2), sphere->radius, random_double(-2,2)));
-        double mat_choice = random_double();
-        if(mat_choice < 0.33){
-            sphere->material = new Lambertian(Vector3::random(0,1));
-        } else if(mat_choice < 0.66){
-            sphere->material = new Metallic(Vector3::random(0,1), random_double(0, 0.5));
-        } else {
-            sphere->material = new Dielectric(Vector3(1, 1, 1), random_double(1.1, 2));
-        }
-
-        scene->add_object(sphere);
-    }
-
-    //environment function
-    scene->set_environment([](Ray ray){
-        auto unit_direction = ray.Direction.unit_vector();
-        auto t = 0.5 * (unit_direction.y + 1.0);
-        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
-    });
-
-    return scene;
-}
-*/
 void Vector3_unit_test(){
     Vector3 v1(1, 2, 3);
     Vector3 v2(4, 5, 6);

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,7 @@
 
 #include "oidn/include/OpenImageDenoise/oidn.hpp"
 #include "Scenes/ManyBallsScene.h"
+#include "Scenes/VolumeTestScene.h"
 
 //TODO: properly fix this by using inherited classes
 std::vector<std::unique_ptr<Scene>> scenes;
@@ -33,6 +34,7 @@ void test_bvh_depth(Scene* scene, Camera* camera, Window* window, int depth_max)
 
 void prepare_scenes(){
     scenes.push_back(std::make_unique<ManyBallsScene>(100));
+    scenes.push_back(std::make_unique<VolumeTestScene>());
 }
 
 int main(int argc, char* argv[]) {
@@ -64,7 +66,7 @@ int main(int argc, char* argv[]) {
 
     //create scene
     //Scene* scene = test_scene_2();
-    Scene* scene = scenes[0].get();
+    Scene* scene = scenes[1].get();
     //build the scene
     scene->init_scene();
     camera->set_scene(scene);
@@ -149,28 +151,6 @@ int main(int argc, char* argv[]) {
     return 0;
 }
 /*
-Scene* volume_test_scene(){
-    Scene* scene = new Scene();
-
-    auto* Ground = new AAB(1000, 0.1, 1000, Vector3(0, -1, 0));
-    Ground->material = new Lambertian(Vector3(0.5, 0.5, 0.5));
-    scene->add_object(Ground);
-
-    auto* sphere = new Sphere(1);
-    sphere->Transform.set_position(Vector3(0, .5, -1));
-    sphere->material = new VolumeTest(Vector3(1, 1, 1), .5, 0.1);
-    scene->add_object(sphere);
-
-    //environment function
-    scene->set_environment([](Ray ray){
-        auto unit_direction = ray.Direction.unit_vector();
-        auto t = 0.5 * (unit_direction.y + 1.0);
-        return (1.0 - t) * Vector3(1, 1, 1) + t * Vector3(0.5, 0.7, 1.0);
-    });
-
-    return scene;
-}
-
 Scene* mat_test_scene(){
     Scene* scene = new Scene();
 


### PR DESCRIPTION
## Scenes Refactor

Moves scenes into their own classes, all neatly stored inside the `~Scenes\*` folders in the project. Also adds a vector of `unique_ptr` for keeping them all available at runtime and allows late initialization of the classes.

### Extra details
- Scene class has now been changed to be abstract.
- A `std::string sceneName` field has been added to it.
- An alternative constructor accepting a string has been added for easy extension of the class.
- A `virtual void init_scene()` method has been added aswell.

#### Intended class definition
Scenes are meant to be defined like this:
```cpp
// .h
class MyScene : public Scene {
    MyScene() : Scene("MySceneName") {};
    void init_scene() override;
}
```

#### Known Issues
- The MatTestScene seems to not be working.
- Cornell Box renders only few pixels and really dark